### PR TITLE
xpad: clarify button arrays

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -228,54 +228,55 @@ static const struct xpad_device {
 	{ 0x0000, 0x0000, "Generic X-Box pad", 0, XTYPE_UNKNOWN }
 };
 
-/* buttons shared with xbox and xbox360 */
-static const signed short xpad_common_btn[] = {
-	BTN_A, BTN_B, BTN_X, BTN_Y,			/* "analog" buttons */
+/* buttons shared with all xbox compatible controllers */
+static const signed short xpad_btn_common[] = {
+	BTN_A, BTN_B, BTN_X, BTN_Y,						/* coloured buttons */
 	BTN_START, BTN_SELECT, BTN_THUMBL, BTN_THUMBR,	/* start/back/sticks */
-	-1						/* terminating entry */
-};
-
-/* original xbox controllers only */
-static const signed short xpad_btn[] = {
-	BTN_C, BTN_Z,		/* "analog" buttons */
-	-1			/* terminating entry */
+	-1												/* terminating entry */
 };
 
 /* used when dpad is mapped to buttons */
-static const signed short xpad_btn_pad[] = {
+static const signed short xpad_btn_dpad[] = {
 	BTN_TRIGGER_HAPPY1, BTN_TRIGGER_HAPPY2,		/* d-pad left, right */
 	BTN_TRIGGER_HAPPY3, BTN_TRIGGER_HAPPY4,		/* d-pad up, down */
-	-1				/* terminating entry */
+	-1											/* terminating entry */
 };
 
 /* used when triggers are mapped to buttons */
 static const signed short xpad_btn_triggers[] = {
 	BTN_TL2, BTN_TR2,		/* triggers left/right */
-	-1
+	-1						/* terminating entry */
 };
 
-static const signed short xpad360_btn[] = {  /* buttons for x360 controller */
-	BTN_TL, BTN_TR,		/* Button LB/RB */
-	BTN_MODE,		/* The big X button */
-	-1
+/* original xbox controllers only */
+static const signed short xpad_btn_original[] = {
+	BTN_C, BTN_Z,		/* "analog" buttons */
+	-1					/* terminating entry */
 };
 
-static const signed short xpad_abs[] = {
+/* buttons for xbox 360 and xbox one controllers */
+static const signed short xpad_btn_360[] = {
+	BTN_TL, BTN_TR,		/* Button LBumper/RBumper */
+	BTN_MODE,			/* The big X button */
+	-1					/* terminating entry */
+};
+
+static const signed short xpad_abs_sticks[] = {
 	ABS_X, ABS_Y,		/* left stick */
 	ABS_RX, ABS_RY,		/* right stick */
-	-1			/* terminating entry */
+	-1					/* terminating entry */
 };
 
 /* used when dpad is mapped to axes */
-static const signed short xpad_abs_pad[] = {
+static const signed short xpad_abs_dpad[] = {
 	ABS_HAT0X, ABS_HAT0Y,	/* d-pad axes */
-	-1			/* terminating entry */
+	-1						/* terminating entry */
 };
 
 /* used when triggers are mapped to axes */
 static const signed short xpad_abs_triggers[] = {
 	ABS_Z, ABS_RZ,		/* triggers left/right */
-	-1
+	-1					/* terminating entry */
 };
 
 /*
@@ -1338,27 +1339,27 @@ static int xpad_init_input(struct usb_xpad *xpad)
 	if (!(xpad->mapping & MAP_STICKS_TO_NULL)) {
 		__set_bit(EV_ABS, input_dev->evbit);
 		/* set up axes */
-		for (i = 0; xpad_abs[i] >= 0; i++)
-			xpad_set_up_abs(input_dev, xpad_abs[i]);
+		for (i = 0; xpad_abs_sticks[i] >= 0; i++)
+			xpad_set_up_abs(input_dev, xpad_abs_sticks[i]);
 	}
 
 	/* set up standard buttons */
-	for (i = 0; xpad_common_btn[i] >= 0; i++)
-		__set_bit(xpad_common_btn[i], input_dev->keybit);
+	for (i = 0; xpad_btn_common[i] >= 0; i++)
+		__set_bit(xpad_btn_common[i], input_dev->keybit);
 
 	/* set up model-specific ones */
 	if (xpad->xtype == XTYPE_XBOX360 || xpad->xtype == XTYPE_XBOX360W ||
 	    xpad->xtype == XTYPE_XBOXONE) {
-		for (i = 0; xpad360_btn[i] >= 0; i++)
-			__set_bit(xpad360_btn[i], input_dev->keybit);
+		for (i = 0; xpad_btn_360[i] >= 0; i++)
+			__set_bit(xpad_btn_360[i], input_dev->keybit);
 	} else {
-		for (i = 0; xpad_btn[i] >= 0; i++)
-			__set_bit(xpad_btn[i], input_dev->keybit);
+		for (i = 0; xpad_btn_original[i] >= 0; i++)
+			__set_bit(xpad_btn_original[i], input_dev->keybit);
 	}
 
 	if (xpad->mapping & MAP_DPAD_TO_BUTTONS) {
-		for (i = 0; xpad_btn_pad[i] >= 0; i++)
-			__set_bit(xpad_btn_pad[i], input_dev->keybit);
+		for (i = 0; xpad_btn_dpad[i] >= 0; i++)
+			__set_bit(xpad_btn_dpad[i], input_dev->keybit);
 	}
 
 	/*
@@ -1369,8 +1370,8 @@ static int xpad_init_input(struct usb_xpad *xpad)
 	 */
 	if (!(xpad->mapping & MAP_DPAD_TO_BUTTONS) ||
 	    xpad->xtype == XTYPE_XBOX360W) {
-		for (i = 0; xpad_abs_pad[i] >= 0; i++)
-			xpad_set_up_abs(input_dev, xpad_abs_pad[i]);
+		for (i = 0; xpad_abs_dpad[i] >= 0; i++)
+			xpad_set_up_abs(input_dev, xpad_abs_dpad[i]);
 	}
 
 	if (xpad->mapping & MAP_TRIGGERS_TO_BUTTONS) {


### PR DESCRIPTION
xpad_common_btn -> xpad_btn_common
xpad_btn_pad -> xpad_btn_dpad
xpad_btn -> xpad_btn_original
xpad360_btn -> xpad_btn_360
xpad_abs -> xpad_abs_sticks
xpad_abs_pad -> xpad_abs_dpad

Signed-off-by: Daniel Tobias <dan.g.tob@gmail.com>

NOTE: github diff view seems to default to tabs=8spaces, seems you can fix it by adding '?ts=4' to the end of the url