### PR TITLE
xpad: print received packets if DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ This driver creates three devices for each attached gamepad
 3. the generic event device
     * example `fftest /dev/input/by-id/usb-*360*event*`
 
+# Debugging
+As a regular unpriveledged user
+
+Setup console to display kernel log.  
+`dmesg --level=debug --follow`
+
+Open a new console and access the device with jstest.  
+`jstest /dev/input/jsX`
+
+Interact with the device and observe that data packets recieved from device are printed to kernel log.
+```
+[ 3968.772128] xpad-dbg: 00000000: 20 00 b5 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 40 fe 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.772135] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804137] xpad-dbg: 00000000: 20 00 b6 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 fc fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804145] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152120] xpad-dbg: 00000000: 20 00 b7 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 b8 fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152129] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
+
+Save dmesg buffer and attach to bug report, don't forget to describe button sequences in bug report.  
+`dmesg --level=debug > dmesg.txt`
+
+Ctrl+C to close interactive console sessions when finished.
+
 # Sending Upstream
 
 1. `git format-patch --cover-letter upstream..master`

--- a/xpad.c
+++ b/xpad.c
@@ -714,6 +714,13 @@ static void xpad_irq_in(struct urb *urb)
 		goto exit;
 	}
 
+#if defined(DEBUG)
+	/* If you set rowsize to larger than 32 it defaults to 16?
+	 * Otherwise I would set it to XPAD_PKT_LEN                  V
+	 */
+	print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, xpad->idata, XPAD_PKT_LEN, 0);
+#endif
+
 	switch (xpad->xtype) {
 	case XTYPE_XBOX360:
 		xpad360_process_packet(xpad, xpad->dev, 0, xpad->idata);


### PR DESCRIPTION
Should help figure out why the rock candy device isn't working correctly, but is probably useful for much more than that #39 #12 