### PR TITLE
add USB id for Hyperkin Duke

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Updated Xpad Linux Kernel Driver
+Driver for the Xbox/ Xbox 360/ Xbox 360 Wireless/ Xbox One Controllers
+
+This driver includes the latest changes in the upstream linux kernel and additionally carries the following staging changes:
+
+* enable debug outputs to ease resolving issues
+* some minor code refactoring improving readability 
+
+# Installing
+```
+sudo git clone https://github.com/paroj/xpad.git /usr/src/xpad-0.4
+sudo dkms install -m xpad -v 0.4
+```
+# Updating
+```
+cd /usr/src/xpad-0.4
+sudo git fetch
+sudo git checkout origin/master
+sudo dkms remove -m xpad -v 0.4 --all
+sudo dkms install -m xpad -v 0.4
+```
+# Removing
+```
+sudo dkms remove -m xpad -v 0.4 --all
+sudo rm -rf /usr/src/xpad-0.4
+```
+# Usage
+This driver creates three devices for each attached gamepad
+
+1. /dev/input/js**N**
+    * example `jstest /dev/input/js0`
+2. /sys/class/leds/xpad**N**/brightness
+    * example `echo COMMAND > /sys/class/leds/xpad0/brightness` where COMMAND is one of
+        *  0: off
+        *  1: all blink, then previous setting
+        *  2: 1/top-left blink, then on
+        *  3: 2/top-right blink, then on
+        *  4: 3/bottom-left blink, then on
+        *  5: 4/bottom-right blink, then on
+        *  6: 1/top-left on
+        *  7: 2/top-right on
+        *  8: 3/bottom-left on
+        *  9: 4/bottom-right on
+        * 10: rotate
+        * 11: blink, based on previous setting
+        * 12: slow blink, based on previous setting
+        * 13: rotate with two lights
+        * 14: persistent slow all blink
+        * 15: blink once, then previous setting
+3. the generic event device
+    * example `fftest /dev/input/by-id/usb-*360*event*`
+
+# Debugging
+As a regular unpriveledged user
+
+Setup console to display kernel log.  
+`dmesg --level=debug --follow`
+
+Open a new console and access the device with jstest.  
+`jstest /dev/input/jsX`
+
+Interact with the device and observe that data packets recieved from device are printed to kernel log.
+```
+[ 3968.772128] xpad-dbg: 00000000: 20 00 b5 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 40 fe 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.772135] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804137] xpad-dbg: 00000000: 20 00 b6 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 fc fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804145] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152120] xpad-dbg: 00000000: 20 00 b7 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 b8 fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152129] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
+
+Save dmesg buffer and attach to bug report, don't forget to describe button sequences in bug report.  
+`dmesg --level=debug > dmesg.txt`
+
+Ctrl+C to close interactive console sessions when finished.
+
+# Sending Upstream
+
+1. `git format-patch --cover-letter upstream..master`
+2. `git send-email --to xxx *.patch`

--- a/stress_urb_out.sh
+++ b/stress_urb_out.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# stress test irq_urb_out. provokes URB request dropping.
+# script by Laura Abbott
+# see: http://www.spinics.net/lists/linux-input/msg40477.html
+
+while true; do
+    for i in $(seq 0 5); do
+        echo $i > /sys/class/leds/xpad0/subsystem/xpad0/brightness
+    done
+done

--- a/xpad.c
+++ b/xpad.c
@@ -143,6 +143,7 @@ static const struct xpad_device {
 	{ 0x045e, 0x02dd, "Microsoft X-Box One pad (Firmware 2015)", 0, XTYPE_XBOXONE },
 	{ 0x045e, 0x02e3, "Microsoft X-Box One Elite pad", 0, XTYPE_XBOXONE },
 	{ 0x045e, 0x02ea, "Microsoft X-Box One S pad", 0, XTYPE_XBOXONE },
+	{ 0x2e24, 0x0652, "Hyperkin Duke X-Box One pad", 0, XTYPE_XBOXONE },
 	{ 0x045e, 0x0719, "Xbox 360 Wireless Receiver", MAP_DPAD_TO_BUTTONS, XTYPE_XBOX360W },
 	{ 0x046d, 0xc21d, "Logitech Gamepad F310", 0, XTYPE_XBOX360 },
 	{ 0x046d, 0xc21e, "Logitech Gamepad F510", 0, XTYPE_XBOX360 },
@@ -413,6 +414,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster X-Box 360 controllers */
 	XPAD_XBOX360_VENDOR(0x045e),		/* Microsoft X-Box 360 controllers */
 	XPAD_XBOXONE_VENDOR(0x045e),		/* Microsoft X-Box One controllers */
+	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
 	XPAD_XBOX360_VENDOR(0x046d),		/* Logitech X-Box 360 style controllers */
 	XPAD_XBOX360_VENDOR(0x056e),		/* Elecom JC-U3613M */
 	XPAD_XBOX360_VENDOR(0x06a3),		/* Saitek P3600 */

--- a/xpad.c
+++ b/xpad.c
@@ -1925,7 +1925,6 @@ static struct usb_driver xpad_driver = {
 	.disconnect	= xpad_disconnect,
 	.suspend	= xpad_suspend,
 	.resume		= xpad_resume,
-	.reset_resume	= xpad_resume,
 	.id_table	= xpad_table,
 };
 

--- a/xpad.c
+++ b/xpad.c
@@ -903,6 +903,13 @@ static void xpad_irq_in(struct urb *urb)
 		goto exit;
 	}
 
+#if defined(DEBUG_VERBOSE)
+	/* If you set rowsize to larger than 32 it defaults to 16?
+	 * Otherwise I would set it to XPAD_PKT_LEN                  V
+	 */
+	print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, xpad->idata, XPAD_PKT_LEN, 0);
+#endif
+
 	switch (xpad->xtype) {
 	case XTYPE_XBOX360:
 		xpad360_process_packet(xpad, xpad->dev, 0, xpad->idata);

--- a/xpad.c
+++ b/xpad.c
@@ -74,7 +74,7 @@
  *
  * Later changes can be tracked in SCM.
  */
-
+// #define DEBUG
 #include <linux/kernel.h>
 #include <linux/input.h>
 #include <linux/rcupdate.h>


### PR DESCRIPTION
dmesg output when connected:
[ 1062.548922] usb 3-3.3: USB disconnect, device number 17
[ 1063.540794] usb 3-3.3: new full-speed USB device number 18 using xhci_hcd
[ 1063.642840] usb 3-3.3: New USB device found, idVendor=2e24, idProduct=0652
[ 1063.642844] usb 3-3.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 1063.642847] usb 3-3.3: Product: Hyperkin Duke
[ 1063.642850] usb 3-3.3: Manufacturer: DDR
[ 1063.642852] usb 3-3.3: SerialNumber: 000080DEEE37BDE8
[ 1063.643766] input: Hyperkin Duke X-Box One pad as /devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.3/3-3.3:1.0/input/input25