### PR TITLE
add support for atplay xbox one wired controller

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -230,6 +230,7 @@ static const struct xpad_device {
 	{ 0x0e6f, 0x02a1, "PDP Xbox One Controller", 0, XTYPE_XBOXONE },
 	{ 0x0e6f, 0x02a7, "PDP Xbox One Controller", 0, XTYPE_XBOXONE },
 	{ 0x0e6f, 0x02a8, "PDP Xbox One Controller", 0, XTYPE_XBOXONE },
+	{ 0x0e6f, 0x02b2, "@Play Xbox One Controller", 0, XTYPE_XBOXONE },
 	{ 0x0e6f, 0x0164, "PDP Battlefield One", 0, XTYPE_XBOXONE },
 	{ 0x0e6f, 0x0165, "PDP Titanfall 2", 0, XTYPE_XBOXONE },
 	{ 0x0e6f, 0x0201, "Pelican PL-3601 'TSZ' Wired Xbox 360 Controller", 0, XTYPE_XBOX360 },


### PR DESCRIPTION
This commit adds support for the [GS-048-114](http://www.atplayaccessories.com/products/XboxOne-Wired-Controller.html) XBox One wired controller, USB device ID `0e6f:02b2`.

Tested on Ubuntu 18.04.1, kernel version 4.15.0-43-generic.