### PR TITLE
Added new device entry for PowerA X Series controller

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -306,6 +306,7 @@ static const struct xpad_device {
 	{ 0x1bad, 0xfd00, "Razer Onza TE", 0, XTYPE_XBOX360 },
 	{ 0x1bad, 0xfd01, "Razer Onza", 0, XTYPE_XBOX360 },
 	{ 0x20d6, 0x281f, "PowerA Wired Controller For Xbox 360", 0, XTYPE_XBOX360 },
+	{ 0x20d6, 0x2001, "PowerA Wired Controller For Xbox Series X", 0, XTYPE_XBOXONE },
 	{ 0x24c6, 0x5000, "Razer Atrox Arcade Stick", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOX360 },
 	{ 0x24c6, 0x5300, "PowerA MINI PROEX Controller", 0, XTYPE_XBOX360 },
 	{ 0x24c6, 0x5303, "Xbox Airflo wired controller", 0, XTYPE_XBOX360 },


### PR DESCRIPTION
Prior to adding this line, the xpad driver was not being loaded for this device.

The command `lusb -t` show no driver present.
`Port 5: Dev 8, If 0, Class=Vendor Specific Class, Driver=, 12M`

Even though the vendorID was in the xpad_table. After this commit the controller worked as expected.

This controller "PowerA Enhanced Wired Controller for Xbox" is currently Amazon's choice for third-party XBox One controllers, so I am guessing there are others who could benefit from it's support.