### PR TITLE
Input: xpad - add support for Nacon GC100 controller

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -451,6 +451,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOXONE_VENDOR(0x24c6),		/* PowerA Controllers */
 	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
 	XPAD_XBOX360_VENDOR(0x2f24),		/* GameSir Controllers */
+	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon Controllers */
 	{ }
 };
 


### PR DESCRIPTION
Got the Nacon GC100 (newer version of GC100-XF) to work as expected when in xinput mode using this addition
Shows in lsusb as: `Bus 001 Device 002: ID 3285:0607 Nacon GC100`

Like the PR-template says, the `xpad_table` entry seems to be enough so there is none for `xpad_device`