### PR TITLE
Add controller 20d6:2005

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+<!--
+If you are adding support for a new generic xpad controller it is sufficient
+to update the xpad_table[] array.
+The type will be auto-detected in xpad_probe().
+Updating the xpad_device[] array is only needed if the controller requires
+additional flags like DANCEPAD_MAP_CONFIG to work.
+ -->

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Updated Xpad Linux Kernel Driver
+Driver for the Xbox/ Xbox 360/ Xbox 360 Wireless/ Xbox One Controllers
+
+This driver includes the latest changes in the upstream linux kernel and additionally carries the following staging changes:
+
+* enable debug outputs to ease resolving issues
+* some minor code refactoring improving readability 
+
+
+**This driver does not support the XBox One Wireless Adapter (WiFi)**  
+To get that running, see: [medusalix/xow](https://github.com/medusalix/xow)
+
+# Installing
+```
+sudo git clone https://github.com/paroj/xpad.git /usr/src/xpad-0.4
+sudo dkms install -m xpad -v 0.4
+```
+# Updating
+```
+cd /usr/src/xpad-0.4
+sudo git fetch
+sudo git checkout origin/master
+sudo dkms remove -m xpad -v 0.4 --all
+sudo dkms install -m xpad -v 0.4
+```
+# Removing
+```
+sudo dkms remove -m xpad -v 0.4 --all
+sudo rm -rf /usr/src/xpad-0.4
+```
+# Usage
+This driver creates three devices for each attached gamepad
+
+1. /dev/input/js**N**
+    * example `jstest /dev/input/js0`
+2. /sys/class/leds/xpad**N**/brightness
+    * example `echo COMMAND > /sys/class/leds/xpad0/brightness` where COMMAND is one of
+        *  0: off
+        *  1: all blink, then previous setting
+        *  2: 1/top-left blink, then on
+        *  3: 2/top-right blink, then on
+        *  4: 3/bottom-left blink, then on
+        *  5: 4/bottom-right blink, then on
+        *  6: 1/top-left on
+        *  7: 2/top-right on
+        *  8: 3/bottom-left on
+        *  9: 4/bottom-right on
+        * 10: rotate
+        * 11: blink, based on previous setting
+        * 12: slow blink, based on previous setting
+        * 13: rotate with two lights
+        * 14: persistent slow all blink
+        * 15: blink once, then previous setting
+3. the generic event device
+    * example `fftest /dev/input/by-id/usb-*360*event*`
+
+# Debugging
+As a regular unpriveledged user
+
+Setup console to display kernel log.  
+`dmesg --level=debug --follow`
+
+Open a new console and access the device with jstest.  
+`jstest /dev/input/jsX`
+
+Interact with the device and observe that data packets recieved from device are printed to kernel log.
+```
+[ 3968.772128] xpad-dbg: 00000000: 20 00 b5 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 40 fe 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.772135] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804137] xpad-dbg: 00000000: 20 00 b6 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 fc fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3968.804145] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152120] xpad-dbg: 00000000: 20 00 b7 0e 00 00 00 00 00 00 0c 03 04 fd 6c 01 b8 fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[ 3969.152129] xpad-dbg: 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
+
+Save dmesg buffer and attach to bug report, don't forget to describe button sequences in bug report.  
+`dmesg --level=debug > dmesg.txt`
+
+Ctrl+C to close interactive console sessions when finished.
+
+# Sending Upstream
+
+1. `git format-patch --cover-letter upstream..master`
+2. `git send-email --to xxx *.patch`

--- a/stress_urb_out.sh
+++ b/stress_urb_out.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# stress test irq_urb_out. provokes URB request dropping.
+# script by Laura Abbott
+# see: http://www.spinics.net/lists/linux-input/msg40477.html
+
+while true; do
+    for i in $(seq 0 5); do
+        echo $i > /sys/class/leds/xpad0/subsystem/xpad0/brightness
+    done
+done

--- a/xpad.c
+++ b/xpad.c
@@ -60,7 +60,7 @@
  *
  * Later changes can be tracked in SCM.
  */
-
+// #define DEBUG
 #include <linux/kernel.h>
 #include <linux/input.h>
 #include <linux/rcupdate.h>

--- a/xpad.c
+++ b/xpad.c
@@ -451,6 +451,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOXONE_VENDOR(0x24c6),		/* PowerA Controllers */
 	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
 	XPAD_XBOX360_VENDOR(0x2f24),		/* GameSir Controllers */
+	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon Controllers */
 	{ }
 };
 

--- a/xpad.c
+++ b/xpad.c
@@ -609,11 +609,13 @@ struct usb_xpad {
 	int pad_nr;			/* the order x360 pads were attached */
 	const char *name;		/* name of the device */
 	struct work_struct work;	/* init/remove device from callback */
+	time64_t mode_btn_down_ts;
 };
 
 static int xpad_init_input(struct usb_xpad *xpad);
 static void xpad_deinit_input(struct usb_xpad *xpad);
 static void xpadone_ack_mode_report(struct usb_xpad *xpad, u8 seq_num);
+static void xpad360w_poweroff_controller(struct usb_xpad *xpad);
 
 /*
  *	xpad_process_packet
@@ -765,6 +767,23 @@ static void xpad360_process_packet(struct usb_xpad *xpad, struct input_dev *dev,
 	}
 
 	input_sync(dev);
+
+	/* XBOX360W controllers can't be turned off without driver assistance */
+	if (xpad->xtype == XTYPE_XBOX360W) {
+		if (xpad->mode_btn_down_ts > 0
+		&& xpad->pad_present
+		&& (ktime_get_seconds() - xpad->mode_btn_down_ts) >= 5) {
+			xpad360w_poweroff_controller(xpad);
+			xpad->mode_btn_down_ts = 0;
+			return;
+		}
+
+		/* mode button down/up */
+		if (data[3] & 0x04)
+			xpad->mode_btn_down_ts = ktime_get_seconds();
+		else
+			xpad->mode_btn_down_ts = 0;
+	}
 }
 
 static void xpad_presence_work(struct work_struct *work)

--- a/xpad.c
+++ b/xpad.c
@@ -336,6 +336,7 @@ static const struct xpad_device {
 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
 	{ 0x3767, 0x0101, "Fanatec Speedster 3 Forceshock Wheel", 0, XTYPE_XBOX },
 	{ 0xffff, 0xffff, "Chinese-made Xbox Controller", 0, XTYPE_XBOX },
+	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
 	{ 0x0000, 0x0000, "Generic X-Box pad", 0, XTYPE_UNKNOWN }
 };
 
@@ -452,6 +453,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
 	XPAD_XBOX360_VENDOR(0x2f24),		/* GameSir Controllers */
 	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon Controllers */
+	XPAD_XBOX360_VENDOR(0x2563),		/* OneXPlayer Gamepad */
 	{ }
 };
 

--- a/xpad.c
+++ b/xpad.c
@@ -1977,7 +1977,6 @@ static struct usb_driver xpad_driver = {
 	.disconnect	= xpad_disconnect,
 	.suspend	= xpad_suspend,
 	.resume		= xpad_resume,
-	.reset_resume	= xpad_resume,
 	.id_table	= xpad_table,
 };
 

--- a/xpad.c
+++ b/xpad.c
@@ -308,6 +308,7 @@ static const struct xpad_device {
 	{ 0x1bad, 0xfd00, "Razer Onza TE", 0, XTYPE_XBOX360 },
 	{ 0x1bad, 0xfd01, "Razer Onza", 0, XTYPE_XBOX360 },
 	{ 0x20d6, 0x2001, "BDA Xbox Series X Wired Controller", 0, XTYPE_XBOXONE },
+	{ 0x20d6, 0x2005, "PowerA Xbox Series X Wired Controller OPP Black", XTYPE_XBOXONE },
 	{ 0x20d6, 0x2009, "PowerA Enhanced Wired Controller for Xbox Series X|S", 0, XTYPE_XBOXONE },
 	{ 0x20d6, 0x281f, "PowerA Wired Controller For Xbox 360", 0, XTYPE_XBOX360 },
 	{ 0x2e24, 0x0652, "Hyperkin Duke X-Box One pad", 0, XTYPE_XBOXONE },

--- a/xpad.c
+++ b/xpad.c
@@ -952,6 +952,13 @@ static void xpad_irq_in(struct urb *urb)
 		goto exit;
 	}
 
+#if defined(DEBUG_VERBOSE)
+	/* If you set rowsize to larger than 32 it defaults to 16?
+	 * Otherwise I would set it to XPAD_PKT_LEN                  V
+	 */
+	print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, xpad->idata, XPAD_PKT_LEN, 0);
+#endif
+
 	switch (xpad->xtype) {
 	case XTYPE_XBOX360:
 		xpad360_process_packet(xpad, xpad->dev, 0, xpad->idata);

--- a/xpad.c
+++ b/xpad.c
@@ -308,7 +308,7 @@ static const struct xpad_device {
 	{ 0x1bad, 0xfd00, "Razer Onza TE", 0, XTYPE_XBOX360 },
 	{ 0x1bad, 0xfd01, "Razer Onza", 0, XTYPE_XBOX360 },
 	{ 0x20d6, 0x2001, "BDA Xbox Series X Wired Controller", 0, XTYPE_XBOXONE },
-	{ 0x20d6, 0x2005, "PowerA Xbox Series X Wired Controller OPP Black", XTYPE_XBOXONE },
+	{ 0x20d6, 0x2005, "PowerA Xbox Series X Wired Controller OPP Black", 0, XTYPE_XBOXONE },
 	{ 0x20d6, 0x2009, "PowerA Enhanced Wired Controller for Xbox Series X|S", 0, XTYPE_XBOXONE },
 	{ 0x20d6, 0x281f, "PowerA Wired Controller For Xbox 360", 0, XTYPE_XBOX360 },
 	{ 0x2e24, 0x0652, "Hyperkin Duke X-Box One pad", 0, XTYPE_XBOXONE },


### PR DESCRIPTION
<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.
 -->