### PR TITLE
Input: xpadone - add support for XBOX One Elite paddles (attempt #2)

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -349,7 +349,7 @@ static const struct xpad_device {
 static const signed short xpad_common_btn[] = {
 	BTN_A, BTN_B, BTN_X, BTN_Y,			/* "analog" buttons */
 	BTN_START, BTN_SELECT, BTN_THUMBL, BTN_THUMBR,	/* start/back/sticks */
-	BTN_0, BTN_1, BTN_2, BTN_3, /* elite paddles */
+	BTN_TRIGGER_HAPPY5, BTN_TRIGGER_HAPPY6, BTN_TRIGGER_HAPPY7, BTN_TRIGGER_HAPPY8, /* elite paddles */
 	-1						/* terminating entry */
 };
 
@@ -906,10 +906,10 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 	input_report_key(dev, BTN_Y,	data[4] & 0x80);
 
 	/* elite paddles */
-	input_report_key(dev, BTN_0,	data[18] & 0x04);
-	input_report_key(dev, BTN_1,	data[18] & 0x08);
-	input_report_key(dev, BTN_2,	data[18] & 0x01);
-	input_report_key(dev, BTN_3,	data[18] & 0x02);
+	input_report_key(dev, BTN_TRIGGER_HAPPY5,	data[18] & 0x04);
+	input_report_key(dev, BTN_TRIGGER_HAPPY6,	data[18] & 0x08);
+	input_report_key(dev, BTN_TRIGGER_HAPPY7,	data[18] & 0x01);
+	input_report_key(dev, BTN_TRIGGER_HAPPY8,	data[18] & 0x02);
 
 	/* digital pad */
 	if (xpad->mapping & MAP_DPAD_TO_BUTTONS) {

--- a/xpad.c
+++ b/xpad.c
@@ -61,6 +61,7 @@
  * Later changes can be tracked in SCM.
  */
 // #define DEBUG
+// #define DEBUG_VERBOSE
 #include <linux/kernel.h>
 #include <linux/input.h>
 #include <linux/rcupdate.h>
@@ -348,6 +349,7 @@ static const struct xpad_device {
 static const signed short xpad_common_btn[] = {
 	BTN_A, BTN_B, BTN_X, BTN_Y,			/* "analog" buttons */
 	BTN_START, BTN_SELECT, BTN_THUMBL, BTN_THUMBR,	/* start/back/sticks */
+	BTN_0, BTN_1, BTN_2, BTN_3, /* elite paddles */
 	-1						/* terminating entry */
 };
 
@@ -902,6 +904,12 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 	input_report_key(dev, BTN_B,	data[4] & 0x20);
 	input_report_key(dev, BTN_X,	data[4] & 0x40);
 	input_report_key(dev, BTN_Y,	data[4] & 0x80);
+
+	/* elite paddles */
+	input_report_key(dev, BTN_0,	data[18] & 0x04);
+	input_report_key(dev, BTN_1,	data[18] & 0x08);
+	input_report_key(dev, BTN_2,	data[18] & 0x01);
+	input_report_key(dev, BTN_3,	data[18] & 0x02);
 
 	/* digital pad */
 	if (xpad->mapping & MAP_DPAD_TO_BUTTONS) {

--- a/xpad.c
+++ b/xpad.c
@@ -61,7 +61,6 @@
  * Later changes can be tracked in SCM.
  */
 // #define DEBUG
-// #define DEBUG_VERBOSE
 #include <linux/kernel.h>
 #include <linux/input.h>
 #include <linux/rcupdate.h>

--- a/xpad.c
+++ b/xpad.c
@@ -509,6 +509,15 @@ static const u8 xboxone_s_init[] = {
 };
 
 /*
+ * This packet is required to get additional input data
+ * from Xbox One Elite Series 2 (0x045e:0x0b00) pads.
+ * We mostly do this right now to get paddle data
+ */
+static const u8 extra_input_packet_init[] = {
+	0x4d, 0x10, 0x01, 0x02, 0x07, 0x00
+};
+
+/*
  * This packet is required for the Titanfall 2 Xbox One pads
  * (0x0e6f:0x0165) to finish initialization and for Hori pads
  * (0x0f0d:0x0067) to make the analog sticks work.
@@ -568,6 +577,7 @@ static const struct xboxone_init_packet xboxone_init_packets[] = {
 	XBOXONE_INIT_PKT(0x0000, 0x0000, xboxone_fw2015_init),
 	XBOXONE_INIT_PKT(0x045e, 0x02ea, xboxone_s_init),
 	XBOXONE_INIT_PKT(0x045e, 0x0b00, xboxone_s_init),
+	XBOXONE_INIT_PKT(0x045e, 0x0b00, extra_input_packet_init),
 	XBOXONE_INIT_PKT(0x0e6f, 0x0000, xboxone_pdp_init1),
 	XBOXONE_INIT_PKT(0x0e6f, 0x0000, xboxone_pdp_init2),
 	XBOXONE_INIT_PKT(0x24c6, 0x541a, xboxone_rumblebegin_init),

--- a/xpad.c
+++ b/xpad.c
@@ -405,8 +405,8 @@ static const signed short xpad_abs_triggers[] = {
 
 /* used when the controller has extra paddle buttons */
 static const signed short xpad_btn_paddles[] = {
-	BTN_TRIGGER_HAPPY5, BTN_TRIGGER_HAPPY6, /* paddle upper left, lower left */
-	BTN_TRIGGER_HAPPY7, BTN_TRIGGER_HAPPY8, /* paddle upper right, lower right */
+	BTN_TRIGGER_HAPPY5, BTN_TRIGGER_HAPPY6, /* paddle upper right, lower right */
+	BTN_TRIGGER_HAPPY7, BTN_TRIGGER_HAPPY8, /* paddle upper left, lower left */
 	-1						/* terminating entry */
 };
 
@@ -924,10 +924,10 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 			}
 
 			/* Elite Series 2 split packet paddle bits */
-			input_report_key(dev, BTN_TRIGGER_HAPPY5, data[18] & 0x04);
-			input_report_key(dev, BTN_TRIGGER_HAPPY6, data[18] & 0x08);
-			input_report_key(dev, BTN_TRIGGER_HAPPY7, data[18] & 0x01);
-			input_report_key(dev, BTN_TRIGGER_HAPPY8, data[18] & 0x02);
+			input_report_key(dev, BTN_TRIGGER_HAPPY5, data[18] & 0x01);
+			input_report_key(dev, BTN_TRIGGER_HAPPY6, data[18] & 0x02);
+			input_report_key(dev, BTN_TRIGGER_HAPPY7, data[18] & 0x04);
+			input_report_key(dev, BTN_TRIGGER_HAPPY8, data[18] & 0x08);
 
 			do_sync = true;
 		}
@@ -1003,10 +1003,10 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 					data[32] = 0;
 				}
 				/* OG Elite Series Controller paddle bits */
-				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[32] & 0x01);
-				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[32] & 0x04);
-				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[32] & 0x02);
-				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[32] & 0x08);
+				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[32] & 0x02);
+				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[32] & 0x08);
+				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[32] & 0x01);
+				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[32] & 0x04);
 			} else if (xpad->ptype == PTYPE_ETWOOLD){
 				/* Mute paddles if controller is in a custom profile slot */
 				/* Checked by looking at the active profile slot to verify it's the default slot */
@@ -1015,10 +1015,10 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 				}
 
 				/* Elite Series 2 4.x firmware paddle bits */
-				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[18] & 0x04);
-				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[18] & 0x08);
-				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[18] & 0x01);
-				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[18] & 0x02);
+				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[18] & 0x01);
+				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[18] & 0x02);
+				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[18] & 0x04);
+				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[18] & 0x08);
 			} else if (xpad->ptype == PTYPE_ETWO5){
 				/* Mute paddles if controller is in a custom profile slot */
 				/* Checked by looking at the active profile slot to verify it's the default slot */
@@ -1027,10 +1027,10 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 				}
 
 				/* Elite Series 2 5.x firmware paddle bits (before the packet was split) */
-				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[22] & 0x04);
-				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[22] & 0x08);
-				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[22] & 0x01);
-				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[22] & 0x02);
+				input_report_key(dev, BTN_TRIGGER_HAPPY5, data[22] & 0x01);
+				input_report_key(dev, BTN_TRIGGER_HAPPY6, data[22] & 0x02);
+				input_report_key(dev, BTN_TRIGGER_HAPPY7, data[22] & 0x04);
+				input_report_key(dev, BTN_TRIGGER_HAPPY8, data[22] & 0x08);
 			}
 		}
 


### PR DESCRIPTION
Resolves #31

Second attempt at adding support for XBOX One Elite paddles. This time using BTN_TRIGGER_HAPPY for the paddles instead of BTN. See #194 regarding why the first attempt had to be reverted, see #193 for the original PR.

I've used jstest to verify the bits are working as expected. The button mapping works out as follows:
| Paddle Position | Mapping | Button Number |
| --- | --- | :--- |
| Left hand, upper | BTN_HAPPY3 | 13 |
| Left hand, lower | BTN_HAPPY4 | 14 |
| Right hand, upper | BTN_HAPPY1 | 11 |
| Right hand, lower | BTN_HAPPY2 | 12 |

_Positions correspond to a normal holding position (i.e.: left side = side with DPAD)_

An effort has been made to support every official model and firmware version I could track down info on. The following controllers _should_ have working paddles with this PR:
- Xbox Elite (**untested**)
- Xbox Elite Series 2 on early firmwares (**untested**)
- Xbox Elite Series 2 on v4 firmwares (Tested v4.8.1908.0)
- Xbox Elite Series 2 on v5 pre-BLE firmwares (**untested**)
- Xbox Elite Series 2 on v5 post-BLE firmwares (Tested v5.13.3143.0)

**Note**: When using custom profile slots, pressing a paddle will light up **both** the paddle's bits AND the mapped button's bits (_assuming the paddles are mapped to another face button_). For this reason, whenever it is detected that a non-default profile is loaded (For the Elite 1: when paddles are remapped. For the Elite 2: whenever it's not using profile slot 0)