### PR TITLE
Add Brook zpp4000 PS3/PS4 to PS Classic/PS2 Super Converter

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -449,6 +449,7 @@ static const struct usb_device_id xpad_table[] = {
 	{ USB_DEVICE(0x0738, 0x4540) },		/* Mad Catz Beat Pad */
 	XPAD_XBOXONE_VENDOR(0x0738),		/* Mad Catz FightStick TE 2 */
 	XPAD_XBOX360_VENDOR(0x07ff),		/* Mad Catz GamePad */
+	XPAD_XBOX360_VENDOR(0x0c12),		/* Zeroplus X-Box 360 controllers */
 	XPAD_XBOX360_VENDOR(0x0e6f),		/* 0x0e6f X-Box 360 controllers */
 	XPAD_XBOXONE_VENDOR(0x0e6f),		/* 0x0e6f X-Box One controllers */
 	XPAD_XBOX360_VENDOR(0x0f0d),		/* Hori Controllers */


### PR DESCRIPTION
<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.
 -->
[Brook PS3/PS4 to PS Classic/PS2 Super Converter](https://www.brookaccessory.com/detail/44237976/)
[My Blog about this converter (zpp4000)](https://noabody.wordpress.com/2022/04/06/brook-ps3-ps4-to-ps-classic-ps2-super-converter/)

Although 0c12 exists in xpad_device array, this adapter is not recognized as a Generic Xbox 360 gamepad until 0c12 is also added as a vendor in the xpad_table array.  It is the only addition.

As a side note, in Arch-like Manjaro Qonos 21.2.5, xpad (either existing kernel module or one added via dkms) doesn't load on system start or device insertion.  I'm working around this problem with a targetted udev rule that can be done easily by adding the VID/PID of the device:

`echo 'ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0c12", ATTRS{idProduct}=="08f1", RUN+="/usr/bin/modprobe xpad"' | sudo tee -a /etc/udev/rules.d/90-xpad.rules`