### PR TITLE
Input: xpad - add quriks for 360 controllers

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -101,6 +101,12 @@
 #define PKT_XBE2_FW_5_EARLY 3
 #define PKT_XBE2_FW_5_11    4
 
+#define QUIRK_360_START_PKT_1	(1 << 0)
+#define QUIRK_360_START_PKT_2	(1 << 1)
+#define QUIRK_360_START_PKT_3	(1 << 2)
+#define QUIRK_360_START (QUIRK_360_START_PKT_1 |			\
+				QUIRK_360_START_PKT_2 | QUIRK_360_START_PKT_3)
+
 static bool dpad_to_buttons;
 module_param(dpad_to_buttons, bool, S_IRUGO);
 MODULE_PARM_DESC(dpad_to_buttons, "Map D-PAD to buttons rather than axes for unknown pads");
@@ -123,7 +129,7 @@ static const struct xpad_device {
 	char *name;
 	u8 mapping;
 	u8 xtype;
-	u8 packet_type;
+	u8 quirks;
 } xpad_device[] = {
 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
 	{ 0x03eb, 0xff01, "Wooting One (Legacy)", 0, XTYPE_XBOX360 },
@@ -157,6 +163,7 @@ static const struct xpad_device {
 	{ 0x046d, 0xca8a, "Logitech Precision Vibration Feedback Wheel", 0, XTYPE_XBOX },
 	{ 0x046d, 0xcaa3, "Logitech DriveFx Racing Wheel", 0, XTYPE_XBOX360 },
 	{ 0x056e, 0x2004, "Elecom JC-U3613M", 0, XTYPE_XBOX360 },
+	{ 0x05ac, 0x055b, "Gamesir-G3w", 0, XTYPE_XBOX360, QUIRK_360_START },
 	{ 0x05fd, 0x1007, "Mad Catz Controller (unverified)", 0, XTYPE_XBOX },
 	{ 0x05fd, 0x107a, "InterAct 'PowerPad Pro' X-Box pad (Germany)", 0, XTYPE_XBOX },
 	{ 0x05fe, 0x3030, "Chic Controller", 0, XTYPE_XBOX },
@@ -261,6 +268,7 @@ static const struct xpad_device {
 	{ 0x0f0d, 0x0067, "HORIPAD ONE", 0, XTYPE_XBOXONE },
 	{ 0x0f0d, 0x0078, "Hori Real Arcade Pro V Kai Xbox One", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOXONE },
 	{ 0x0f0d, 0x00c5, "Hori Fighting Commander ONE", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOXONE },
+	{ 0x0f0d, 0x00dc, "HORIPAD FPS for Nintendo Switch", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOX360, QUIRK_360_START_PKT_1 },
 	{ 0x0f30, 0x010b, "Philips Recoil", 0, XTYPE_XBOX },
 	{ 0x0f30, 0x0202, "Joytech Advanced Controller", 0, XTYPE_XBOX },
 	{ 0x0f30, 0x8888, "BigBen XBMiniPad Controller", 0, XTYPE_XBOX },
@@ -660,6 +668,7 @@ struct usb_xpad {
 	int xtype;			/* type of xbox device */
 	int packet_type;		/* type of the extended packet */
 	int pad_nr;			/* the order x360 pads were attached */
+	int quirks;
 	const char *name;		/* name of the device */
 	struct work_struct work;	/* init/remove device from callback */
 	time64_t mode_btn_down_ts;
@@ -1379,70 +1388,74 @@ static int xpad_start_xbox_360(struct usb_xpad *xpad)
 	Sending this sequence to other controllers will break initialization.
 	*/
 	bool is_shanwan = strcasecmp("shanwan", xpad->udev->manufacturer) == 0;
-	if ((xpad->dev->id.vendor != 0x05ac ||
-	     xpad->dev->id.product != 0x055b) &&
-	    !is_shanwan) {
+	if (!(xpad->quirks & QUIRK_360_START) && !is_shanwan) {
 		status = 0;
 		goto err_free_ctrl_data;
 	}
 
-	status = usb_control_msg(xpad->udev,
-		usb_rcvctrlpipe(xpad->udev, 0),
-		0x1, 0xc1,
-		cpu_to_le16(0x100), cpu_to_le16(0x0), data, cpu_to_le16(20),
-		TIMEOUT);
+	if ((xpad->quirks & QUIRK_360_START_PKT_1) || is_shanwan) {
+	    status = usb_control_msg(xpad->udev,
+		    usb_rcvctrlpipe(xpad->udev, 0),
+		    0x1, 0xc1,
+		    cpu_to_le16(0x100), cpu_to_le16(0x0), data, cpu_to_le16(20),
+		    TIMEOUT);
 
 #ifdef DEBUG
-	dev_dbg(&xpad->intf->dev,
-		"%s - control message 1 returned %d\n", __func__, status);
+	    dev_dbg(&xpad->intf->dev,
+		    "%s - control message 1 returned %d\n", __func__, status);
 #endif
 
-	if (status < 0) {
-		goto err_free_ctrl_data;
-	}
+	    if (status) {
+		    goto err_free_ctrl_data;
+	    }
 #ifdef DEBUG
-	else {
-		print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 20, 0);
+	    else {
+		    print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 20, 0);
+	    }
+#endif
 	}
+
+	if ((xpad->quirks & QUIRK_360_START_PKT_2) || is_shanwan) {
+	    status = usb_control_msg(xpad->udev,
+		    usb_rcvctrlpipe(xpad->udev, 0),
+		    0x1, 0xc1,
+		    cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(8),
+		    TIMEOUT);
+#ifdef DEBUG
+	    dev_dbg(&xpad->intf->dev,
+		    "%s - control message 2 returned %d\n", __func__, status);
 #endif
 
-	status = usb_control_msg(xpad->udev,
-		usb_rcvctrlpipe(xpad->udev, 0),
-		0x1, 0xc1,
-		cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(8),
-		TIMEOUT);
+	    if (status < 0) {
+		    goto err_free_ctrl_data;
+	    }
 #ifdef DEBUG
-	dev_dbg(&xpad->intf->dev,
-		"%s - control message 2 returned %d\n", __func__, status);
+	    else {
+		    print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 8, 0);
+	    }
+#endif
+	}
+
+	if ((xpad->quirks & QUIRK_360_START_PKT_3) || is_shanwan) {
+	    status = usb_control_msg(xpad->udev,
+		    usb_rcvctrlpipe(xpad->udev, 0),
+		    0x1, 0xc0,
+		    cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(4),
+		    TIMEOUT);
+#ifdef DEBUG
+	    dev_dbg(&xpad->intf->dev,
+		    "%s - control message 3 returned %d\n", __func__, status);
 #endif
 
-	if (status < 0) {
-		goto err_free_ctrl_data;
-	}
+	    if (status < 0) {
+		    goto err_free_ctrl_data;
+	    }
 #ifdef DEBUG
-	else {
-		print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 8, 0);
-	}
+	    else {
+		    print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 4, 0);
+	    }
 #endif
-
-	status = usb_control_msg(xpad->udev,
-		usb_rcvctrlpipe(xpad->udev, 0),
-		0x1, 0xc0,
-		cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(4),
-		TIMEOUT);
-#ifdef DEBUG
-	dev_dbg(&xpad->intf->dev,
-		"%s - control message 3 returned %d\n", __func__, status);
-#endif
-
-	if (status < 0) {
-		goto err_free_ctrl_data;
 	}
-#ifdef DEBUG
-	else {
-		print_hex_dump(KERN_DEBUG, "xpad-dbg: ", DUMP_PREFIX_OFFSET, 32, 1, data, 4, 0);
-	}
-#endif
 
 	status = 0;
 
@@ -2022,6 +2035,7 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 	xpad->mapping = xpad_device[i].mapping;
 	xpad->xtype = xpad_device[i].xtype;
 	xpad->name = xpad_device[i].name;
+	xpad->quirks = xpad_device[i].quirks;
 	xpad->packet_type = PKT_XB;
 	INIT_WORK(&xpad->work, xpad_presence_work);
 


### PR DESCRIPTION
Some third-party Xbox 360 controllers require additional initialization
packets for the controller to start giving input. Some of these controllers
only require one and may break with further, some may require all three. This
change adds a quirks field that allows specifying these initialization
packets, as well as adding the VID/PID for the HORIPAD FPS for Nintendo
Switch, which depends on only the first packet being sent.

Note that it also removes an unused field from the controller type table.

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

To get attribution for your work when this goes upstream, make sure to use
a real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin
 -->