### PR TITLE
input: xpad: Switch to workqueue for xpad360w button poweroff

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -710,6 +710,7 @@ struct usb_xpad {
 	int quirks;
 	const char *name;		/* name of the device */
 	struct work_struct work;	/* init/remove device from callback */
+	struct delayed_work poweroff_work; /* work struct for poweroff on mode long press */
 	time64_t mode_btn_down_ts;
 };
 
@@ -871,20 +872,29 @@ static void xpad360_process_packet(struct usb_xpad *xpad, struct input_dev *dev,
 
 	/* XBOX360W controllers can't be turned off without driver assistance */
 	if (xpad->xtype == XTYPE_XBOX360W) {
-		if (xpad->mode_btn_down_ts > 0 && xpad->pad_present &&
-		    ((ktime_get_seconds() - xpad->mode_btn_down_ts) >=
-		     XPAD360W_POWEROFF_TIMEOUT)) {
-			xpad360w_poweroff_controller(xpad);
-			xpad->mode_btn_down_ts = 0;
-			return;
+		if (data[3] & BIT(2)) {
+			if (xpad->mode_btn_down_ts == 0)
+				xpad->mode_btn_down_ts = ktime_get_seconds();
+			schedule_delayed_work(&xpad->poweroff_work, msecs_to_jiffies(0));
+		} else {
+				xpad->mode_btn_down_ts = 0;
 		}
-
-		/* mode button down/up */
-		if (data[3] & BIT(2))
-			xpad->mode_btn_down_ts = ktime_get_seconds();
-		else
-			xpad->mode_btn_down_ts = 0;
 	}
+}
+
+static void xpad360w_poweroff_work(struct work_struct *work) {
+	struct usb_xpad *xpad = container_of(to_delayed_work(work), struct usb_xpad, poweroff_work);
+
+	if (xpad->mode_btn_down_ts == 0)
+		return;
+
+	if ((ktime_get_seconds() - xpad->mode_btn_down_ts) >= XPAD360W_POWEROFF_TIMEOUT) {
+		xpad360w_poweroff_controller(xpad);
+		xpad->mode_btn_down_ts = 0;
+		return;
+	}
+
+	schedule_delayed_work(&xpad->poweroff_work, msecs_to_jiffies(200));
 }
 
 static void xpad_presence_work(struct work_struct *work)
@@ -1864,6 +1874,8 @@ static int xpad360w_start_input(struct usb_xpad *xpad)
 		return error;
 	}
 
+	INIT_DELAYED_WORK(&xpad->poweroff_work, xpad360w_poweroff_work);
+
 	return 0;
 }
 
@@ -1873,6 +1885,7 @@ static void xpad360w_stop_input(struct usb_xpad *xpad)
 
 	/* Make sure we are done with presence work if it was scheduled */
 	flush_work(&xpad->work);
+	flush_delayed_work(&xpad->poweroff_work);
 }
 
 static int xpad_open(struct input_dev *dev)


### PR DESCRIPTION
* This allows to turn off the pad without having to release the Xbox (mode) button

Signed-off-by: Davide Garberi <dade.garberi@gmail.com>

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

To get attribution for your work when this goes upstream, make sure to use
a real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin
 -->