### PR TITLE
Add support for 8BitDo Ultimate Wireless controller and dongle

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -371,6 +371,7 @@ static const struct xpad_device {
 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
 	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
 	{ 0x2dc8, 0x2000, "8BitDo Pro 2 Wired Controller fox Xbox", 0, XTYPE_XBOXONE },
+	{ 0x2dc8, 0x3106, "8BitDo Ultimate Wireless Controller", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1100, "Wooting One", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1200, "Wooting Two", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1210, "Wooting Lekker", 0, XTYPE_XBOX360 },
@@ -512,6 +513,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOX360_VENDOR(0x2563),		/* OneXPlayer Gamepad */
 	XPAD_XBOX360_VENDOR(0x260d),		/* Dareu H101 */
 	XPAD_XBOXONE_VENDOR(0x2dc8),		/* 8BitDo Pro 2 Wired Controller for Xbox */
+	XPAD_XBOX360_VENDOR(0x2dc8),		/* 8BitDo Ultimate Wireless Controller */
 	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
 	XPAD_XBOX360_VENDOR(0x2f24),		/* GameSir Controllers */
 	XPAD_XBOX360_VENDOR(0x31e3),		/* Wooting Keyboards */


### PR DESCRIPTION
Got this controller today. Plugging it into Windows it shows up as a wired Xbox 360 pad with a vendor ID 0x2dc8 like the other 8BitDo pads, and a device ID of 0x3106. The IDs are the same whether the controller is connected directly with a wire, or via the wireless dongle.

This doesn't include any support for directly seeing the back buttons on the controller, not sure if that's even possible, and I wouldn't even know how to find out.

Edit: I also just verified that this works when the wireless dongle is plugged into the dock as a passthru. IDs and functionality are the same.

Signed-off-by: Josh Cotton <jcotton42@outlook.com>