### PR TITLE
Add support for Keychron HE keyboards

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -578,6 +578,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOX360_VENDOR(0x31e3),		/* Wooting Keyboards */
 	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon GC-100 */
 	XPAD_XBOXONE_VENDOR(0x3285),		/* Nacon Evol-X */
+	XPAD_XBOX360_VENDOR(0x3434),		/* Keychron Keyboards */
 	XPAD_XBOX360_VENDOR(0x3537),		/* GameSir Controllers */
 	XPAD_XBOXONE_VENDOR(0x3537),		/* GameSir Controllers */
 	XPAD_XBOX360_VENDOR(0x413d),		/* Black Shark Green Ghost Controller */


### PR DESCRIPTION
Adding a new vendor ID for Keychron keyboards. 

This should cover the K2, Q1, Q2, Q3, Q4, Q5 and Q6 HE models that have the Gamepad Analog feature.