### PR TITLE
Add support for Surge controllers

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -571,6 +571,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOX360_VENDOR(0x2563),		/* OneXPlayer Gamepad */
 	XPAD_XBOX360_VENDOR(0x260d),		/* Dareu H101 */
        XPAD_XBOXONE_VENDOR(0x294b),            /* Snakebyte */
+	XPAD_XBOXONE_VENDOR(0x2c16),		/* Surge Controllers */
 	XPAD_XBOX360_VENDOR(0x2c22),		/* Qanba Controllers */
 	XPAD_XBOX360_VENDOR(0x2dc8),            /* 8BitDo Pro 2 Wired Controller */
 	XPAD_XBOXONE_VENDOR(0x2dc8),		/* 8BitDo Pro 2 Wired Controller for Xbox */


### PR DESCRIPTION
<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->

Adding support for Surge controllers.

I tested the changes on Ubuntu 24.04 with a Surge Livewire Microwatt controller and everything seems to work with no issues.

https://www.amazon.com/Livewire-Microwatt-Controller-Windows-Gaming-Console/dp/B0CGF9SZZS?ref_=ast_sto_dp&th=1

```console
ubuntu@ubuntu:/usr/src/xpad-0.4$ lsusb -d 2c16:a1b1
Bus 001 Device 056: ID 2c16:a1b1 Priferential Accessories Ltd Surge Wired Controller
```