### PR TITLE
Compatibility with kernel 6.15.0

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -62,6 +62,7 @@
  */
 
 // #define DEBUG
+#include <linux/version.h>
 #include <linux/bits.h>
 #include <linux/kernel.h>
 #include <linux/input.h>
@@ -72,6 +73,11 @@
 #include <linux/usb/input.h>
 #include <linux/usb/quirks.h>
 #include <linux/timer.h>
+
+// backward compatibility. del_timer_sync is renamed to timer_delete_sync since 6.15.0
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
+#define timer_delete_sync del_timer_sync
+#endif
 
 // enable compilation on pre 6.1 kernels
 #ifndef ABS_PROFILE
@@ -2520,7 +2526,7 @@ static void xpad_disconnect(struct usb_interface *intf)
 
 	if (xpad->quirks & QUIRK_GHL_XBOXONE) {
 		usb_free_urb(xpad->ghl_urb);
-		del_timer_sync(&xpad->ghl_poke_timer);
+		timer_delete_sync(&xpad->ghl_poke_timer);
 	}
 
 	usb_free_coherent(xpad->udev, XPAD_PKT_LEN,


### PR DESCRIPTION
Fix #319 

Renamed del_timer_sync to timer_delete_sync.

Reason: https://github.com/torvalds/linux/commit/8fa7292fee5c5240402371ea89ab285ec856c916

Compatibility with older kernels has been preserved.

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->