### PR TITLE
Add controller: Razer Wolverine V3 Pro. Update xpad.c

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -331,6 +331,7 @@ static const struct xpad_device {
 	{ 0x1532, 0x0a00, "Razer Atrox Arcade Stick", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOXONE },
 	{ 0x1532, 0x0a03, "Razer Wildcat", 0, XTYPE_XBOXONE },
 	{ 0x1532, 0x0a29, "Razer Wolverine V2", 0, XTYPE_XBOXONE },
+	{ 0x1532, 0x0a4c, "Razer Wolverine V3 Pro Xbox 360 Mode", 0, XTYPE_XBOX360 },
 	{ 0x15e4, 0x3f00, "Power A Mini Pro Elite", 0, XTYPE_XBOX360 },
 	{ 0x15e4, 0x3f0a, "Xbox Airflo wired controller", 0, XTYPE_XBOX360 },
 	{ 0x15e4, 0x3f10, "Batarang Xbox 360 controller", 0, XTYPE_XBOX360 },


### PR DESCRIPTION
Add support for the Razer Wolverine V3 Pro controller while operating in "PC Tournament Mode", which reports as an Xbox 360 device.

Explanation: The controller can be connected in one of two ways. Wired over USB, or over a packaged dongle. The dongle does not function like a standard Xinput Wireless Dongle and is designed only to pair to the specific model it was packaged with. As far as the operating system is concerned, the dongle is presenting the controller as if it were wired, and it handles all wireless communications on its own. If the controller is off, no device is reported to the host OS. 

Its "default" mode that works with the Xbox Series consoles reports at 250hz. This pull request is for the secondary mode, which when used over a wire supports 1000hz reporting, though you can still engage this mode when connecting the controller to the dongle and it'll report at 250hz just fine. Razer calls this "PC Tournament Mode", and the controller/dongle report to the host OS as an Xbox 360 device. This pull request updates the table to look for the vendor/product ID that matches this mode. Updating the table to have the driver look for this controller allows for force feedback in supported titles.

Note:  The driver can likely be updated to also support the other mode, which reports as an Xbox Series device and utilizes GIP. However, as I've not done extensive personal testing with this mode in use, my commit doesn't include an update for the table that supports that mode.

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->