### PR TITLE
Fixes for the XBOX 360 usb control messages

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -1668,10 +1668,14 @@ static int xpad_start_xbox_360(struct usb_xpad *xpad)
 	}
 
 	if ((xpad->quirks & QUIRK_360_START_PKT_1) || is_shanwan) {
+	    /* Get_Report(0x01), Default Controller Input Report(0x0100) */
 	    status = usb_control_msg(xpad->udev,
 		    usb_rcvctrlpipe(xpad->udev, 0),
-		    0x1, 0xc1,
-		    cpu_to_le16(0x100), cpu_to_le16(0x0), data, cpu_to_le16(20),
+		    0x01,
+		    USB_TYPE_VENDOR | USB_DIR_IN | USB_RECIP_INTERFACE,
+		    0x0100,
+		    xpad->intf->cur_altsetting->desc.bInterfaceNumber,
+		    data, 20,
 		    TIMEOUT);
 
 #ifdef DEBUG
@@ -1690,10 +1694,14 @@ static int xpad_start_xbox_360(struct usb_xpad *xpad)
 	}
 
 	if ((xpad->quirks & QUIRK_360_START_PKT_2) || is_shanwan) {
+	    /* Get_Report(0x01), non-documented request(0x0000) */
 	    status = usb_control_msg(xpad->udev,
 		    usb_rcvctrlpipe(xpad->udev, 0),
-		    0x1, 0xc1,
-		    cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(8),
+		    0x01,
+		    USB_TYPE_VENDOR | USB_DIR_IN | USB_RECIP_INTERFACE,
+		    0x0000,
+		    xpad->intf->cur_altsetting->desc.bInterfaceNumber,
+		    data, 8,
 		    TIMEOUT);
 #ifdef DEBUG
 	    dev_dbg(&xpad->intf->dev,
@@ -1711,10 +1719,13 @@ static int xpad_start_xbox_360(struct usb_xpad *xpad)
 	}
 
 	if ((xpad->quirks & QUIRK_360_START_PKT_3) || is_shanwan) {
+	    /* Get_Report(0x01), Get_Device_ID(0x0000,0x0000) */
 	    status = usb_control_msg(xpad->udev,
 		    usb_rcvctrlpipe(xpad->udev, 0),
-		    0x1, 0xc0,
-		    cpu_to_le16(0x0), cpu_to_le16(0x0), data, cpu_to_le16(4),
+		    0x01,
+		    USB_TYPE_VENDOR | USB_DIR_IN | USB_RECIP_DEVICE,
+		    0x0000, 0x0000,
+		    data, 4,
 		    TIMEOUT);
 #ifdef DEBUG
 	    dev_dbg(&xpad->intf->dev,
@@ -2046,15 +2057,15 @@ static int xpad_start_input(struct usb_xpad *xpad)
 		 */
 		u8 dummy[20];
 
+		/* Get_Report(0x01), Default Controller Input Report(0x0100) */
 		error = usb_control_msg_recv(xpad->udev, 0,
 					     /* bRequest */ 0x01,
 					     /* bmRequestType */
-					     USB_TYPE_VENDOR | USB_DIR_IN |
-						USB_RECIP_INTERFACE,
-					     /* wValue */ 0x100,
-					     /* wIndex */ 0x00,
+					     USB_TYPE_VENDOR | USB_DIR_IN | USB_RECIP_INTERFACE,
+					     /* wValue */ 0x0100,
+					     /* wIndex */ xpad->intf->cur_altsetting->desc.bInterfaceNumber,
 					     dummy, sizeof(dummy),
-					     25, GFP_KERNEL);
+					     50, GFP_KERNEL);
 		if (error)
 			dev_warn(&xpad->dev->dev,
 				 "unable to receive magic message: %d\n",


### PR DESCRIPTION
1)
XBOX 360 usb control messages for an interface, need the correct Interface specified. Currently this is set to a fixed value of Interface 0. This is needed for usb devices that do not have the XBOX 360 on the first Interface, and/or for usb devices that have multiple XBOX 360 Interfaces.

2)
Removed the cpu_to_le16() usage from the recently added 'QUIRK_360_START' packets, as this is handled by the function usb_control_msg() and not by the user of this function.

Signed-off-by: M Bakker <mbakker@embenco.nl>