### PR TITLE
Compatibility with kernel 6.16.0

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -79,6 +79,11 @@
 #define timer_delete_sync del_timer_sync
 #endif
 
+// backward compatibility. from_timer is renamed to timer_container_of since 6.16.0
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)
+#define timer_container_of from_timer
+#endif
+
 // enable compilation on pre 6.1 kernels
 #ifndef ABS_PROFILE
 #define ABS_PROFILE ABS_MISC
@@ -846,7 +851,7 @@ static void ghl_magic_poke_cb(struct urb *urb)
 static void ghl_magic_poke(struct timer_list *t)
 {
 	int ret;
-	struct usb_xpad *xpad = from_timer(xpad, t, ghl_poke_timer);
+	struct usb_xpad *xpad = timer_container_of(xpad, t, ghl_poke_timer);
 
 	ret = usb_submit_urb(xpad->ghl_urb, GFP_ATOMIC);
 	if (ret < 0)


### PR DESCRIPTION
Renamed del_timer_sync to timer_delete_sync.

Reason: https://github.com/torvalds/linux/commit/41cb08555c416

Compatibility with older kernels has been preserved.

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->