### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you get past the pairing issues, the controller will operate in the [generic-
 The xpad driver will not be used.
 
 **Connecting via XBox One Wireless Adapter (WiFi)**  
-The adapter needs daemon in userspace, see: [medusalix/xow](https://github.com/medusalix/xow)  
+The adapter needs kernel-space driver, see: [dlundqvist/xone](https://github.com/dlundqvist/xone)  
 Opinion: rather get a controller that supports bluetooth.
 
 


### PR DESCRIPTION
xow is VERY outdated, and even the repo recommends using xone. xone has been maintained by dlundqvist for some time, as it seems medusalix has been MIA for some time. Using xone requires an paroj/xpad fork called xpad-noone to be used.

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Kevin <36553759+forkymcforkface@users.noreply.github.com>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->