### PR TITLE
Input: xpad - Add support for CRKD Guitars

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -435,6 +435,7 @@ static const struct xpad_device {
 	{ 0x3285, 0x0662, "Nacon Revolution5 Pro", 0, XTYPE_XBOX360 },
 	{ 0x3285, 0x0663, "Nacon Evol-X", 0, XTYPE_XBOXONE },
 	{ 0x3537, 0x1004, "GameSir T4 Kaleid", 0, XTYPE_XBOX360 },
+	{ 0x3651, 0x1000, "CRKD SG", 0, XTYPE_XBOX360 },
 	{ 0x3767, 0x0101, "Fanatec Speedster 3 Forceshock Wheel", 0, XTYPE_XBOX },
 	{ 0x413d, 0x2104, "Black Shark Green Ghost Gamepad", 0, XTYPE_XBOX360 },
 	{ 0xffff, 0xffff, "Chinese-made Xbox Controller", 0, XTYPE_XBOX },
@@ -597,6 +598,7 @@ static const struct usb_device_id xpad_table[] = {
 	XPAD_XBOXONE_VENDOR(0x3285),		/* Nacon Evol-X */
 	XPAD_XBOX360_VENDOR(0x3537),		/* GameSir Controllers */
 	XPAD_XBOXONE_VENDOR(0x3537),		/* GameSir Controllers */
+	XPAD_XBOX360_VENDOR(0x3651),		/* CRKD Controllers */
 	XPAD_XBOX360_VENDOR(0x413d),		/* Black Shark Green Ghost Controller */
 	{ }
 };

--- a/xpad.c
+++ b/xpad.c
@@ -160,6 +160,8 @@ static const struct xpad_device {
 } xpad_device[] = {
 	/* Please keep this list sorted by vendor and product ID. */
 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
+	{ 0x0351, 0x1000, "CRKD LP Blueberry Burst Pro Edition (Xbox)", 0, XTYPE_XBOX360 },
+	{ 0x0351, 0x2000, "CRKD LP Black Tribal Edition (Xbox) ", 0, XTYPE_XBOX360 },
 	{ 0x03eb, 0xff01, "Wooting One (Legacy)", 0, XTYPE_XBOX360 },
 	{ 0x03eb, 0xff02, "Wooting Two (Legacy)", 0, XTYPE_XBOX360 },
 	{ 0x03f0, 0x038D, "HyperX Clutch", 0, XTYPE_XBOX360 },			/* wired */
@@ -535,6 +537,7 @@ static const struct usb_device_id xpad_table[] = {
 	 */
 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* Xbox USB-IF not-approved class */
 	XPAD_XBOX360_VENDOR(0x0079),		/* GPD Win 2 controller */
+	XPAD_XBOX360_VENDOR(0x0351),		/* CRKD Controllers */
 	XPAD_XBOX360_VENDOR(0x03eb),		/* Wooting Keyboards (Legacy) */
 	XPAD_XBOX360_VENDOR(0x03f0),		/* HP HyperX Xbox 360 controllers */
 	XPAD_XBOXONE_VENDOR(0x03f0),		/* HP HyperX Xbox One controllers */

--- a/xpad.c
+++ b/xpad.c
@@ -150,6 +150,20 @@ static bool auto_poweroff = true;
 module_param(auto_poweroff, bool, S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(auto_poweroff, "Power off wireless controllers on suspend");
 
+struct xpad_x360_gamepad_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u8 reserved[2];
+    u8 subtype;
+    u8 reserved2;
+    u8 bEndpointAddressIn;
+    u8 bMaxDataSizeIn;
+    u8 reserved3[5];
+    u8 bEndpointAddressOut;
+    u8 bMaxDataSizeOut;
+    u8 reserved4[2];
+} __attribute__((packed));
+
 static const struct xpad_device {
 	u16 idVendor;
 	u16 idProduct;
@@ -820,6 +834,7 @@ struct usb_xpad {
 	int packet_type;		/* type of the extended packet */
 	int pad_nr;			/* the order x360 pads were attached */
 	int quirks;
+	int subtype;
 	const char *name;		/* name of the device */
 	struct work_struct work;	/* init/remove device from callback */
 	struct delayed_work poweroff_work; /* work struct for poweroff on mode long press */
@@ -828,6 +843,28 @@ struct usb_xpad {
 	struct timer_list ghl_poke_timer;	/* Timer for periodic poke of GHL magic data */
 };
 
+
+static ssize_t
+subtype_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct usb_xpad *xpad = input_get_drvdata(to_input_dev(dev));
+	return sysfs_emit(buf, "%d\n", xpad->subtype);
+}
+static DEVICE_ATTR_RO(subtype);
+
+static struct attribute *xpad_attrs[] = {
+	&dev_attr_subtype.attr,
+	NULL
+};
+static struct attribute_group xpad_group = {
+      .attrs = xpad_attrs,
+	  .name = "xpad"
+};
+
+static const struct attribute_group *xpad_groups[] = {
+      &xpad_group,
+      NULL,
+};
 static int xpad_init_input(struct usb_xpad *xpad);
 static void xpad_deinit_input(struct usb_xpad *xpad);
 static void xpadone_ack_mode_report(struct usb_xpad *xpad, u8 seq_num);
@@ -1116,11 +1153,15 @@ static void xpad360w_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned cha
 	/* Presence change */
 	if (data[0] & 0x08) {
 		present = (data[1] & 0x80) != 0;
-
 		if (xpad->pad_present != present) {
 			xpad->pad_present = present;
 			schedule_work(&xpad->work);
 		}
+	}
+
+	/* Link report */
+	if (data[0] == 0x00 && data[1] == 0x0F) {
+		xpad->subtype = data[25] & 0x7f;
 	}
 
 	/* Valid pad data */
@@ -2215,6 +2256,7 @@ static void xpad_deinit_input(struct usb_xpad *xpad)
 static int xpad_init_input(struct usb_xpad *xpad)
 {
 	struct input_dev *input_dev;
+	struct xpad_x360_gamepad_descriptor *input_desc;
 	int i, error;
 
 	input_dev = input_allocate_device();
@@ -2224,11 +2266,20 @@ static int xpad_init_input(struct usb_xpad *xpad)
 	xpad->dev = input_dev;
 	input_dev->name = xpad->name;
 	input_dev->phys = xpad->phys;
+	xpad->subtype = 1;
+	xpad->dev->dev.groups = xpad_groups;
+
 	usb_to_input_id(xpad->udev, &input_dev->id);
 
 	if (xpad->xtype == XTYPE_XBOX360W) {
 		/* x360w controllers and the receiver have different ids */
 		input_dev->id.product = 0x02a1;
+	}
+
+	if (xpad->xtype == XTYPE_XBOX360) {
+		if (usb_get_extra_descriptor(xpad->intf->cur_altsetting, 0x21, &input_desc) != -1) {
+			xpad->subtype = input_desc->subtype;
+		}
 	}
 
 	input_dev->dev.parent = &xpad->intf->dev;


### PR DESCRIPTION
This commit adds support for CRKD LP Guitar Controllers

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->